### PR TITLE
Cubehelix

### DIFF
--- a/demo/Cubehelix Demo.ipynb
+++ b/demo/Cubehelix Demo.ipynb
@@ -60,7 +60,7 @@
     {
      "data": {
       "text/html": [
-       "<style type=\"text/css\">table.blockgrid {border: none;} .blockgrid tr {border: none;} .blockgrid td {padding: 0px;} #blocks2eaf98ba-5c3e-4f84-b8f2-0fe299f1aac6 td {border: 1px solid white;}</style><table id=\"blocks2eaf98ba-5c3e-4f84-b8f2-0fe299f1aac6\" class=\"blockgrid\"><tbody><tr><td title=\"Index: [0, 0]&#10;Color: (135, 59, 97)\" style=\"width: 100px; height: 100px;background-color: rgb(135, 59, 97);\"></td><td title=\"Index: [0, 1]&#10;Color: (125, 98, 202)\" style=\"width: 100px; height: 100px;background-color: rgb(125, 98, 202);\"></td><td title=\"Index: [0, 2]&#10;Color: (63, 181, 207)\" style=\"width: 100px; height: 100px;background-color: rgb(63, 181, 207);\"></td><td title=\"Index: [0, 3]&#10;Color: (100, 230, 115)\" style=\"width: 100px; height: 100px;background-color: rgb(100, 230, 115);\"></td><td title=\"Index: [0, 4]&#10;Color: (233, 213, 117)\" style=\"width: 100px; height: 100px;background-color: rgb(233, 213, 117);\"></td></tr></tbody></table>"
+       "<style type=\"text/css\">table.blockgrid {border: none;} .blockgrid tr {border: none;} .blockgrid td {padding: 0px;} #blocks95599e51-f8ca-40ac-ab8d-c759d05c1486 td {border: 1px solid white;}</style><table id=\"blocks95599e51-f8ca-40ac-ab8d-c759d05c1486\" class=\"blockgrid\"><tbody><tr><td title=\"Index: [0, 0]&#10;Color: (135, 59, 97)\" style=\"width: 100px; height: 100px;background-color: rgb(135, 59, 97);\"></td><td title=\"Index: [0, 1]&#10;Color: (125, 98, 202)\" style=\"width: 100px; height: 100px;background-color: rgb(125, 98, 202);\"></td><td title=\"Index: [0, 2]&#10;Color: (63, 181, 207)\" style=\"width: 100px; height: 100px;background-color: rgb(63, 181, 207);\"></td><td title=\"Index: [0, 3]&#10;Color: (100, 230, 115)\" style=\"width: 100px; height: 100px;background-color: rgb(100, 230, 115);\"></td><td title=\"Index: [0, 4]&#10;Color: (233, 213, 117)\" style=\"width: 100px; height: 100px;background-color: rgb(233, 213, 117);\"></td></tr></tbody></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -73,7 +73,7 @@
    "source": [
     "cube = cubehelix.Cubehelix.make(n=5, start_hue=240., end_hue=-300.,min_sat=1., max_sat=2.5,\n",
     "                                min_light=0.3, max_light=0.8, gamma=.9)\n",
-    "cube.show_as_blocks()"
+    "cube.show_as_blocks()  # requires ipythonblocks"
    ]
   },
   {
@@ -164,9 +164,9 @@
    "source": [
     "## Pre-made Cubehelix Maps\n",
     "\n",
-    "Of course, you can also use a number of off-the-shelf color maps. These pre-made cubehelix maps have 256 computed colors, so they are ideal for continuous color scales. Like the other color maps in Palettable, the cubehelix maps are available from the `palettable.cubehelix` namespace.\n",
+    "Of course, you can also use a number of pre-made color maps. The pre-made cubehelix maps have 16 computed colors. Since matplotlib's color maps are linearly interpolated, these work great as continuous color maps.\n",
     "\n",
-    "Here is a listing of color map names:"
+    "Like the other color maps in Palettable, the cubehelix maps are available from the `palettable.cubehelix` namespace. Here is a listing of color map names:"
    ]
   },
   {
@@ -180,14 +180,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "classic               sequential      \n",
-      "perceptual_rainbow    sequential      \n",
-      "purple                sequential      \n",
-      "jim_special           sequential      \n",
-      "red                   sequential      \n",
-      "cubehelix1            sequential      \n",
-      "cubehelix2            sequential      \n",
-      "cubehelix3            sequential      \n"
+      "classic_16               sequential      \n",
+      "perceptual_rainbow_16    sequential      \n",
+      "purple_16                sequential      \n",
+      "jim_special_16           sequential      \n",
+      "red_16                   sequential      \n",
+      "cubehelix1_16            sequential      \n",
+      "cubehelix2_16            sequential      \n",
+      "cubehelix3_16            sequential      \n"
      ]
     }
    ],
@@ -221,7 +221,7 @@
     }
    ],
    "source": [
-    "cubehelix.classic.show_continuous_image()"
+    "cubehelix.classic_16.show_continuous_image()"
    ]
   },
   {
@@ -243,7 +243,7 @@
     }
    ],
    "source": [
-    "cubehelix.perceptual_rainbow.show_continuous_image()"
+    "cubehelix.perceptual_rainbow_16.show_continuous_image()"
    ]
   },
   {
@@ -265,7 +265,7 @@
     }
    ],
    "source": [
-    "cubehelix.purple.show_continuous_image()"
+    "cubehelix.purple_16.show_continuous_image()"
    ]
   },
   {
@@ -287,7 +287,7 @@
     }
    ],
    "source": [
-    "cubehelix.jim_special.show_continuous_image()"
+    "cubehelix.jim_special_16.show_continuous_image()"
    ]
   },
   {
@@ -309,7 +309,7 @@
     }
    ],
    "source": [
-    "cubehelix.red.show_continuous_image()"
+    "cubehelix.red_16.show_continuous_image()"
    ]
   },
   {
@@ -331,7 +331,7 @@
     }
    ],
    "source": [
-    "cubehelix.cubehelix1.show_continuous_image()"
+    "cubehelix.cubehelix1_16.show_continuous_image()"
    ]
   },
   {
@@ -353,7 +353,7 @@
     }
    ],
    "source": [
-    "cubehelix.cubehelix2.show_continuous_image()"
+    "cubehelix.cubehelix2_16.show_continuous_image()"
    ]
   },
   {
@@ -375,7 +375,7 @@
     }
    ],
    "source": [
-    "cubehelix.cubehelix3.show_continuous_image()"
+    "cubehelix.cubehelix3_16.show_continuous_image()"
    ]
   },
   {
@@ -404,7 +404,7 @@
     }
    ],
    "source": [
-    "cubehelix.cubehelix3_r.show_continuous_image()"
+    "cubehelix.cubehelix3_16_r.show_continuous_image()"
    ]
   }
  ],

--- a/demo/Cubehelix Demo.ipynb
+++ b/demo/Cubehelix Demo.ipynb
@@ -1,0 +1,432 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cubehelix Color Maps in Palettable\n",
+    "\n",
+    "Cubehelix was designed by [D.A. Green](http://adsabs.harvard.edu/abs/2011arXiv1108.5083G) to provide a color mapping that would degrade gracefully to grayscale without losing information. This quality makes Cubehelix very useful for continuous colour scales in scientific visualizations that might be printed in grayscale at some point. [James Davenport](http://github.com/jradavenport/cubehelix) popularized Cubehelix among `matplotlib` users, and now this iteration brings Cubehelix to [Palettable's beautiful API](https://jiffyclub.github.io/palettable/) for managing color maps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Cubehelix functionality is contained within the `palettable.cubehelix` name space, and shares the same API as `palettable.tableau`, `palettable.brewer.sequential`, `palettable.qualitative`, `palettable.diverging`, and `palettable.wesandersen`, for instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from palettable import cubehelix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Making your own Cubehelix Maps\n",
+    "\n",
+    "Unlike other color maps, Cubehelix is entirely algorithmic. Thus you can make your own map by instantiating a `Cubehelix` object with the `Cubehelix.make()` class method. For example, to make a color palette with 5 colors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">table.blockgrid {border: none;} .blockgrid tr {border: none;} .blockgrid td {padding: 0px;} #blocks2eaf98ba-5c3e-4f84-b8f2-0fe299f1aac6 td {border: 1px solid white;}</style><table id=\"blocks2eaf98ba-5c3e-4f84-b8f2-0fe299f1aac6\" class=\"blockgrid\"><tbody><tr><td title=\"Index: [0, 0]&#10;Color: (135, 59, 97)\" style=\"width: 100px; height: 100px;background-color: rgb(135, 59, 97);\"></td><td title=\"Index: [0, 1]&#10;Color: (125, 98, 202)\" style=\"width: 100px; height: 100px;background-color: rgb(125, 98, 202);\"></td><td title=\"Index: [0, 2]&#10;Color: (63, 181, 207)\" style=\"width: 100px; height: 100px;background-color: rgb(63, 181, 207);\"></td><td title=\"Index: [0, 3]&#10;Color: (100, 230, 115)\" style=\"width: 100px; height: 100px;background-color: rgb(100, 230, 115);\"></td><td title=\"Index: [0, 4]&#10;Color: (233, 213, 117)\" style=\"width: 100px; height: 100px;background-color: rgb(233, 213, 117);\"></td></tr></tbody></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cube = cubehelix.Cubehelix.make(n=5, start_hue=240., end_hue=-300.,min_sat=1., max_sat=2.5,\n",
+    "                                min_light=0.3, max_light=0.8, gamma=.9)\n",
+    "cube.show_as_blocks()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Cubehelix docstring provides some guidance on how to build custom Cubehelix maps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "        Create an arbitrary Cubehelix color palette from the algorithm.\n",
+      "\n",
+      "        See http://adsabs.harvard.edu/abs/2011arXiv1108.5083G for a technical\n",
+      "        explanation of the algorithm.\n",
+      "\n",
+      "        Parameters\n",
+      "        ----------\n",
+      "        start : scalar, optional\n",
+      "            Sets the starting position in the RGB color space. 0=blue, 1=red,\n",
+      "            2=green. Default is ``0.5`` (purple).\n",
+      "        rotation : scalar, optional\n",
+      "            The number of rotations through the rainbow. Can be positive\n",
+      "            or negative, indicating direction of rainbow. Negative values\n",
+      "            correspond to Blue->Red direction. Default is ``-1.5``.\n",
+      "        start_hue : scalar, optional\n",
+      "            Sets the starting color, ranging from [-360, 360]. Combined with\n",
+      "            `end_hue`, this parameter overrides ``start`` and ``rotation``.\n",
+      "            This parameter is based on the D3 implementation by @mbostock.\n",
+      "            Default is ``None``.\n",
+      "        end_hue : scalar, optional\n",
+      "            Sets the ending color, ranging from [-360, 360]. Combined with\n",
+      "            `start_hue`, this parameter overrides ``start`` and ``rotation``.\n",
+      "            This parameter is based on the D3 implementation by @mbostock.\n",
+      "            Default is ``None``.\n",
+      "        gamma : scalar, optional\n",
+      "            The gamma correction for intensity. Values of ``gamma < 1``\n",
+      "            emphasize low intensities while ``gamma > 1`` emphasises high\n",
+      "            intensities. Default is ``1.0``.\n",
+      "        sat : scalar, optional\n",
+      "            The uniform saturation intensity factor. ``sat=0`` produces\n",
+      "            grayscale, while ``sat=1`` retains the full saturation. Setting\n",
+      "            ``sat>1`` oversaturates the color map, at the risk of clipping\n",
+      "            the color scale. Note that ``sat`` overrides both ``min_stat``\n",
+      "            and ``max_sat`` if set.\n",
+      "        min_sat : scalar, optional\n",
+      "            Saturation at the minimum level. Default is ``1.2``.\n",
+      "        max_sat : scalar, optional\n",
+      "            Satuation at the maximum level. Default is ``1.2``.\n",
+      "        min_light : scalar, optional\n",
+      "            Minimum lightness value. Default is ``0``.\n",
+      "        max_light : scalar, optional\n",
+      "            Maximum lightness value. Default is ``1``.\n",
+      "        n : scalar, optional\n",
+      "            Number of discrete rendered colors. Default is ``256``.\n",
+      "        reverse : bool, optional\n",
+      "            Set to ``True`` to reverse the color map. Will go from black to\n",
+      "            white. Good for density plots where shade -> density.\n",
+      "            Default is ``False``.\n",
+      "        name : str, optional\n",
+      "            Name of the color map (defaults to ``'custom_cubehelix'``).\n",
+      "\n",
+      "        Returns\n",
+      "        -------\n",
+      "        palette : `Cubehelix`\n",
+      "            A Cubehelix color palette.\n",
+      "        \n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cubehelix.Cubehelix.make.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pre-made Cubehelix Maps\n",
+    "\n",
+    "Of course, you can also use a number of off-the-shelf color maps. These pre-made cubehelix maps have 256 computed colors, so they are ideal for continuous color scales. Like the other color maps in Palettable, the cubehelix maps are available from the `palettable.cubehelix` namespace.\n",
+    "\n",
+    "Here is a listing of color map names:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "classic               sequential      \n",
+      "perceptual_rainbow    sequential      \n",
+      "purple                sequential      \n",
+      "jim_special           sequential      \n",
+      "red                   sequential      \n",
+      "cubehelix1            sequential      \n",
+      "cubehelix2            sequential      \n",
+      "cubehelix3            sequential      \n"
+     ]
+    }
+   ],
+   "source": [
+    "cubehelix.print_maps()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAqJJREFUeJzt1Uty4zAMBUCA8v2PHM7CkijZmsxsX1X3RgwA0p8K/bqq\nZgFAmFdVVfeoqqpR72f3qL6sq6rGU63GuT56o79rT/N1PMdY677Mj4+5f9S+zn2aH11z9F57P+fo\n2t/mrXeux2Xuuuf9gX7pddWYt7kac+3pS++Xuc/e7L/09nXv5/b4qdEftf6p3ufGQ637594b86wd\nZ4ye1eNe23rWqLWuqtpqnuds9TR3vPXVO+au+47z7nPvza/9a9hmr/Xe2+q79pr1196tNtf5qz/2\n3rbW53OrbX7X3q85zvU646FWo7Z5r416Ve9zo197bb3T8dHr2mrUWh+9Y+6677rneK3q97r2XvV2\nX9+ea77/Nf9VW3vnfkdnj5rjXqtbb3zMbw+1dedXb3vXb7Wued6h+72dox7u/r1/9D5r79+Sp9q+\n57xXxxmz9n+vc6Zvtf0ftuu8o+us1e/r+cc550eY598fP33vu3z/qNU9/3Pufva71/tb7Nv66F3X\nR2/9Dvw+93Te9esAgCgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyA\nSAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBI\nAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgC\nDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIM\ngEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyASAIMgEgCDIBIAgyA\nSAIMgEh/AKkMaI63ibDhAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.classic.show_continuous_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAntJREFUeJzt1kFu20AMBVDOuLfqcXqY3trTRSSLkmy42w+8t5FCcjgO\nEOR7VNUqAAjzq6rq7+8/VVU1xtzKo0bt77P1xtbdemO2udHm5nnuTa/ajr1fo/XG+Wz1s7033u37\n3FtjnGprzKqtttr8a27sc+N85ucXaj/3ufNdff6oHb1rrd7UVvscx9znHWuMWtu1p9r+3nrP69nW\nu+2d9eauenNX1fNVq89zbWafe55qn+fWXG3v9j3sdddqZ9Zlx71X47xv37/GZW6udma1fffaz/zz\nPv9hR83L2bGqxvM0V+N5fr/0xnzT+88d4zI36lnjMrfPjFqt1u7fvg8fu44do+537fOzn63z3ln3\nvbPe7Kj7XaNWzdvcqvm666j9fI6j15+3ubZjjm9zdao9Vn3szdXmWm+uy9zXfdtz+wN+VLUd+3Pc\nao/V/vOvNnepPdruvm+/s78fO+61R3u/nf2yr98NAFEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEE\nGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQY\nAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgA\nkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACR\nBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEEGACRBBgAkQQYAJEE\nGACRBBgAkQQYAJEEGACRBBgAkQQYAJH+AQqPy8SeUWRkAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.perceptual_rainbow.show_continuous_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAe1JREFUeJzt1Utu3DAQQEGK8f2vbG/szEcUoSDePKBq4wHV05IGMN4x\nxvgcABDzMcYYxzHHy98x/34eT9fOc3/OZ8d8+c7Pvssdx3y5vpsb47g59/oO6/nHrt39x/Pc9r12\nz7bacX02xnrfz8z+7Hnv+4713Pl3/dcdV2er7x5vv91/7Fg+5+q753vu5+/O7c9+Y8fj87h3rzlu\n7t3N7e61uDZX8/sd+7P3Zztfm3P1DlfPeWduNf84m6ff9eo5d2eLa/P92tM77nbMu/dazZ/v9fhd\n781d7bt6r3nxbPv338+NMb7/owEgRsAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASBIw\nAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAA\nSBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMg\nScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAk\nAQMgScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASBIwAJIEDIAkAQMgScAASPoCHAAE\njg1W92IAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.purple.show_continuous_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAktJREFUeJzt1cturDAQRdEqK///y/cOIqAwdJQMj7TWpIltbPqh7K6q\nfwUAYb6qqrpXVVWt+n7tXtXjuqpqvY3VOq+PudXPsdf143Ufq1+um2NVv1tf53V/3/Z2/tx39cu9\nb+uv/R7r15jb160+r4+5Xh/W/WGPWj2e7xrb7/1eN+bnXPcYG5/DNjbXHUP3s473NcaOr+1t7vYe\nxn7H3HnP2OOxXz3O6vn3H/e4nmP+dq6P65x/7LudcbyFMX8+2/Z19fxI5tz2THNu/whfn+3l5/J2\n7/0r6Y/r10/nd9/2+/msvq+r53Osse/+M1x9v+fzuvFMdT/z09z+bKv6tt8xd9wz5875/azqse+1\n5roee9R9Xd/G6nnvucd6WX/N7c/WvX65rs+9rzOv//v7+bMfc25vz+q+tWQ//zkHAIEEDIBIAgZA\nJAEDIJKAARBJwACIJGAARBIwACIJGACRBAyASAIGQCQBAyCSgAEQScAAiCRgAEQSMAAiCRgAkQQM\ngEgCBkAkAQMgkoABEEnAAIgkYABEEjAAIgkYAJEEDIBIAgZAJAEDIJKAARBJwACIJGAARBIwACIJ\nGACRBAyASAIGQCQBAyCSgAEQScAAiCRgAEQSMAAiCRgAkQQMgEgCBkAkAQMgkoABEEnAAIgkYABE\nEjAAIgkYAJEEDIBIAgZAJAEDIJKAARBJwACIJGAARBIwACIJGACRBAyASAIGQCQBAyCSgAEQScAA\niCRgAEQSMAAiCRgAkQQMgEgCBkAkAQMgkoABEEnAAIj0HzCFBI5yKgqeAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.jim_special.show_continuous_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAmNJREFUeJzt1UEO4yAQBMAZsv//8u4hsQHbG+XaUtUl1gADIZG7q+pv\nAUCYP1VV3aOqqro+nz3O2ljGznln7fVQG3PNw9i1NmpUd5/Px9jct89zHOdbx657zR699Xuv66XH\n3PN4nj36cf9Rfet367H0n+PHuj6f17Ff5519l3m3HmdtGT8/676219710Le2Hu+z1a1vL/veav1Q\nq8te/bB/P8/rpd97bK31Q+0zbzvbXHusu9fu8/pp7biv/Ta/+73ml3nHBezzjo1/mz9r97tZ589a\n/3ftcYk95iY9f6TleVl3OVMt91XLd5nf6/KDdVc//ojHWdbLuX6H7U80P9fxbc/nP9i2x7n/vfa9\n33w3fQ6+zFvGxuXCxtjXnPtf+o2xnGl/973P8amd/ef8OW/sa47auua4k95r27v9Vns9zr/mQW21\n15d+x7saAAIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJ\nMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkw\nACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAA\nIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAi\nCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACL9\nA4nhBI5Awi1RAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.red.show_continuous_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAm9JREFUeJzt1sFu6zAMBEBKfv//yc891JZZxwlyXWDmYoWi6LYItB1V\ntRcAhPlXVTXH74dxPOdo63qotf6ns+eZT/197lbjT99s677Xz5x7T/Pe7tVs8+aqzaO2HZ1zPNRq\nrDO9tmasvVar7fi9z/6t5nrHsdf6zhmjtvbzXX3nuTWjzb/W25pR41Yb22/9VqvH2u+Me60eZtS4\n3rXPXpvXuqpqtr5+9rbXz/2Zt2rzeNfxHHOtq+3t49Y3t7d7NeefeatvnR3r2defalVV/7fv+19r\ntb68e3vu1xf6Za+2/bX27Yx5/C97Pse+1mP1t57ed6/1cx/6xjj79mt9POeHvXe1ea+NvcZ8nXvd\nDWetXvfGtTe+7Hucd/zptnHeDbV6rvviofbhLnusjXHNud1z23HT3Pf6HXbN+KKv3YfnXr/nRrtf\nz71+551zx8vd1/rajHG/D9dnAAgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgk\nwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTA\nAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAA\niCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACI\nJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgkwACIJMAAiCTAAIgk\nwACIJMAAiCTAAIj0A9v3XY6yIp10AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.cubehelix1.show_continuous_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAmdJREFUeJzt1s1uFDEQhdEqN+//yJgF/ePpbimDxOZK52zilD0OQsEf\nXVWzACDMr6qqGv33u96/jrdZv59b94+vj1ldnzvv2IdjXOsfZ32tj711fz3f42W2VR/r2vY/0qjq\n7dy/z7pePvt2fr1v3xu32aitxn5f7599n42P9XHuOPOcjXO9nXvjY33srevz3P73+rr3xR1bdW3V\n5/q7Wf3j+XW2f/b89ZrLfdfefTZ6nt/f71hnY/8/3XrH8dnRs7aaj9m5vu1tXa9762f//vznrHtW\nj98vs2N92xvznB1nRj9nvfz84/7uWbXv13LfOTv/DR/fX3v9MrvO1XVu3bvdO8dt/dNez+/Ojbf7\nrndo7r/7c3m/jvXH7PamzeXcx+zl3P2Nmm/v3PpW/Ydz97fq401bz9xmVc93rnt8dd/1jl1vxFje\nvvu50eN8X8eyt76Xx95698cdBQCBBAyASAIGQCQBAyCSgAEQScAAiCRgAEQSMAAiCRgAkQQMgEgC\nBkAkAQMgkoABEEnAAIgkYABEEjAAIgkYAJEEDIBIAgZAJAEDIJKAARBJwACIJGAARBIwACIJGACR\nBAyASAIGQCQBAyCSgAEQScAAiCRgAEQSMAAiCRgAkQQMgEgCBkAkAQMgkoABEEnAAIgkYABEEjAA\nIgkYAJEEDIBIAgZAJAEDIJKAARBJwACIJGAARBIwACIJGACRBAyASAIGQCQBAyCSgAEQScAAiCRg\nAEQSMAAiCRgAkQQMgEgCBkAkAQMgkoABEEnAAIgkYABEEjAAIgkYAJEEDIBIAgZAJAEDIJKAARBJ\nwACI9AdkqE6Olv82VQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.cubehelix2.show_continuous_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAndJREFUeJzt1stu2zAURdFLSf7/H67NDPQwZSlp2tkB1gIK0ZcUg2bg\nnVZVvQAgzFJVVVNbP83bdGrv2bj3v7Pbve2Htblqms6zaV7nl9kvz1Wtd37uteX4L1d7vGdtOf06\nzrO/nDv2Hjd727qvz1aP9+y0d561/t25/fN43/mOpc/Hc1yvb97M+lyPPl1mxx11M/s49+jrv3Xd\nbmZ1mS3DuZ/P35zb/uZa9ln1evQ+/rbuZ8PnfX3cdTcbflZrz/VZz5qG9b43rse9qb1u967nrnfU\n9KdqXFdVTc+qNqzHvfY8r/e9/dz43k/n5n32Gtafe8/zuX3vn8/193Ncn87f7H03G9/55lyfW/Xt\ne+g1t2NWVdWn9l4Ps9c8HevjjmF/n71uZn37/nltz/FzbzezYz0de5/v9nadje+evpuqqtV8mVVb\nqn3OhnOnvV/cN23fFXPNNdXdbN5my2U2D3vX2Xx6Z7x3KwIAZBEwACIJGACRBAyASAIGQCQBAyCS\ngAEQScAAiCRgAEQSMAAiCRgAkQQMgEgCBkAkAQMgkoABEEnAAIgkYABEEjAAIgkYAJEEDIBIAgZA\nJAEDIJKAARBJwACIJGAARBIwACIJGACRBAyASAIGQCQBAyCSgAEQScAAiCRgAEQSMAAiCRgAkQQM\ngEgCBkAkAQMgkoABEEnAAIgkYABEEjAAIgkYAJEEDIBIAgZAJAEDIJKAARBJwACIJGAARBIwACIJ\nGACRBAyASAIGQCQBAyCSgAEQScAAiCRgAEQSMAAiCRgAkQQMgEgCBkAkAQMgkoABEEnAAIgkYABE\nEjAAIgkYAJEEDIBIAgZAJAEDINIXqvKhjqCom4sAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.cubehelix3.show_continuous_image()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of course, you can can reverse any color map by appending `_r` to the map's name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbAAAABICAYAAACX+KDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAAoFJREFUeJzt1cFO6zAURdGbwv//cGv7DRo3bhMQerMjrTWxe+0EhET3\nVlWjACDMd1VVG4+qqmrVqqqq16P6vj9mrXp93mtvz5xn72et2mtW+8+s8ahxMZv7sc4+7o3l3uc6\nqp1mW2916+21r6q69VbbuJi99v3HZ+dz7/ePO1sb+/653to4zbaL2a31t/O3tR/3bxezatuxrvuq\nqn47z67urWu//eG9X1Xt6/gZVc/P/evY/3bvdLY8d3Wvfz/3Y86+j2fG9+/35ue+3JvP9Z/vjf0d\no76qL/t5tu7Xsz5ul2fne+d33Gurx/4nvtdzc9+2/b/pfVZV9fjYz7N573K2vP8+9691XMyOde4f\n2zjNru7dL+49tvZa1/3z9/357L718/2tvT3z07NVj6ptfk/cj9nH2Tob2x/vzfetZ+Pj3tjvjKuz\ndfbHe2P53easz+/Kfe39mK1np9kf7/W+vHuu8zto2a/r/PP/z2x993K2fzsAQBYBAyCSgAEQScAA\niCRgAEQSMAAiCRgAkQQMgEgCBkAkAQMgkoABEEnAAIgkYABEEjAAIgkYAJEEDIBIAgZAJAEDIJKA\nARBJwACIJGAARBIwACIJGACRBAyASAIGQCQBAyCSgAEQScAAiCRgAEQSMAAiCRgAkQQMgEgCBkAk\nAQMgkoABEEnAAIgkYABEEjAAIgkYAJEEDIBIAgZAJAEDIJKAARBJwACIJGAARBIwACIJGACRBAyA\nSAIGQCQBAyCSgAEQScAAiCRgAEQSMAAiCRgAkQQMgEgCBkAkAQMgkoABEEnAAIgkYABEEjAAIgkY\nAJEEDIBIAgZAJAEDIJKAARBJwACIJGAARBIwACL9A87IjKC/SWF0AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cubehelix.cubehelix3_r.show_continuous_image()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/cubehelix/index.md.tpl
+++ b/docs/cubehelix/index.md.tpl
@@ -1,0 +1,96 @@
+---
+title: 'Cubehelix Palettes'
+layout: page
+content: []
+---
+
+Cubehelix was designed by [D.A. Green](http://adsabs.harvard.edu/abs/2011arXiv1108.5083G) to provide a color mapping that would degrade gracefully to grayscale without losing information.
+This quality makes Cubehelix useful for continuous color scales in scientific visualizations that might be printed in grayscale at some point.
+
+The `palettable.cubehelix` module provides several pre-made Cubehelix palettes, or you can [make your own](#make).
+
+### See Also
+
+- *[A colour scheme for the display of astronomical intensity images](http://adsabs.harvard.edu/abs/2011BASI...39..289G)*, D.A. Green (2011) Bulletin of the Astronomical Society of India, 39, 289
+- *[Cubehelix, or How I Learned to Love Black & White Printers](http://www.ifweassume.com/2013/05/cubehelix-or-how-i-learned-to-love.html)* by James Davenport.
+
+# Contents
+
+- Previews
+{% for p in palettes %}
+    * [{{p}}](#{{p | lower}})
+{%- endfor %}
+
+- [Making your own Cubehelix palette](#make)
+
+# Previews
+
+{% for p in palettes %}
+<section id="{{p | lower}}">
+    <p class="h4">{{p}}</p>
+
+    <div><img src="./img/{{p + '_continuous.png'}}" alt="{{p + ' continuous'}}"></div>
+    <br>
+    <div><img src="./img/{{p + '_discrete.png'}}" alt="{{p + ' discrete'}}"></div>
+
+</section>
+{% endfor %}
+
+
+<a id="make"></a>
+# Making your own Cubehelix palette
+
+With the `Cubehelix.make` classmethod you can create arbitrary Cubehelix palettes.
+For example:
+
+    from palettable.cubehelix import Cubehelix
+    palette = Cubehelix.make(start=0.3, rotation=-0.5, n=16)
+
+and then use that `palette` instance as usual.
+
+
+## `Cubehelix.make` Argument Reference
+
+- `start` (scalar, optional).
+    Sets the starting position in the RGB color space. 0=blue, 1=red,
+    2=green. Default is `0.5` (purple).
+- `rotation` (scalar, optional).
+    The number of rotations through the rainbow. Can be positive
+    or negative, indicating direction of rainbow. Negative values
+    correspond to Blue&rarr;Red direction. Default is `-1.5`.
+- `start_hue` (scalar, optional).
+    Sets the starting color, ranging from (-360, 360). Combined with
+    `end_hue`, this parameter overrides `start` and `rotation`.
+    This parameter is based on the D3 implementation by @mbostock.
+    Default is `None`.
+- `end_hue` (scalar, optional)
+    Sets the ending color, ranging from (-360, 360). Combined with
+    `start_hue`, this parameter overrides ``start`` and ``rotation``.
+    This parameter is based on the D3 implementation by @mbostock.
+    Default is ``None``.
+- `gamma` (scalar, optional).
+    The gamma correction for intensity. Values of `gamma < 1`
+    emphasize low intensities while `gamma > 1` emphasises high
+    intensities. Default is `1.0`.
+- `sat` (scalar, optional).
+    The uniform saturation intensity factor. `sat=0` produces
+    grayscale, while `sat=1` retains the full saturation. Setting
+    `sat>1` oversaturates the color map, at the risk of clipping
+    the color scale. Note that `sat` overrides both `min_stat`
+    and `max_sat` if set.
+- `min_sat` (scalar, optional).
+    Saturation at the minimum level. Default is `1.2`.
+- `max_sat` (scalar, optional).
+    Satuation at the maximum level. Default is `1.2`.
+- `min_light` (scalar, optional).
+    Minimum lightness value. Default is `0`.
+- `max_light` (scalar, optional).
+    Maximum lightness value. Default is `1`.
+- `n` (scalar, optional).
+    Number of discrete rendered colors. Default is `256`.
+- `reverse` (bool, optional).
+    Set to `True` to reverse the color map. Will go from black to
+    white. Good for density plots where shade &rarr; density.
+    Default is `False`.
+- `name` (str, optional).
+    Name of the color map (defaults to `'custom_cubehelix'`).

--- a/docs/gendocs.py
+++ b/docs/gendocs.py
@@ -17,7 +17,8 @@ MODULES = {
     'palettable.colorbrewer.qualitative': './colorbrewer/qualitative',
     'palettable.colorbrewer.sequential': './colorbrewer/sequential',
     'palettable.tableau': './tableau',
-    'palettable.wesanderson': './wesanderson'
+    'palettable.wesanderson': './wesanderson',
+    'palettable.cubehelix': './cubehelix'
 }
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ supply colors for a web application.
 Palettable has color palettes from:
 
 - [Colorbrewer2][colorbrewer]
+- [Cubehelix][cubehelix]
 - [Tableau][tableau]
 - The [Wes Anderson Palettes][wesanderson] blog
 

--- a/palettable/cubehelix/__init__.py
+++ b/palettable/cubehelix/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/palettable/cubehelix/__init__.py
+++ b/palettable/cubehelix/__init__.py
@@ -1,3 +1,5 @@
 from __future__ import absolute_import
 
-from .cubehelix import __doc__, Cubehelix
+from .cubehelix import __doc__, Cubehelix, print_maps, get_map, _get_all_maps
+
+globals().update(_get_all_maps())

--- a/palettable/cubehelix/__init__.py
+++ b/palettable/cubehelix/__init__.py
@@ -1,1 +1,3 @@
 from __future__ import absolute_import
+
+from .cubehelix import __doc__, Cubehelix

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -2,8 +2,8 @@
 """
 Cubehelix color maps and palettes.
 
-The Cubehelix algorithm makes color scales with monotonic changes in percieved
-brightness. This means that a cubehelix color map automatically transforms to
+The Cubehelix algorithm makes color scales with monotonic changes in perceived
+brightness. This means that a cubehelix color map gracefully degrades into
 a monotonic grayscale color map when rendered without color.
 
 Cubehelix maps are generated algorithmically, giving the user flexibility
@@ -232,6 +232,24 @@ class Cubehelix(Palette):
     """
     Representation of a Cubehelix color map with matplotlib compatible
     views of the map.
+
+    Parameters
+    ----------
+    name : str
+    colors : list
+        Colors as list of 0-255 RGB triplets.
+
+    Attributes
+    ----------
+    name : str
+    type : str
+    number : int
+        Number of colors in color map.
+    colors : list
+        Colors as list of 0-255 RGB triplets.
+    hex_colors : list
+    mpl_colors : list
+    mpl_colormap : matplotlib LinearSegmentedColormap
 
     """
     url = url

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -59,19 +59,19 @@ palette_type = 'sequential'
 
 
 palette_names = [
-    'classic',
-    'perceptual_rainbow',
-    'purple',
-    'jim_special',
-    'red',
-    'cubehelix1',
-    'cubehelix2',
-    'cubehelix3'
+    'classic_16',
+    'perceptual_rainbow_16',
+    'purple_16',
+    'jim_special_16',
+    'red_16',
+    'cubehelix1_16',
+    'cubehelix2_16',
+    'cubehelix3_16'
 ]
 
 
 palette_rgb = dict((
-    ('classic',
+    ('classic_16',
      # dict(start=0.5, rotation=-1.5, gamma=1.0, sat=1.2,
      #      min_light=0., max_light=1., n=16)
      [[0, 0, 0],
@@ -90,7 +90,7 @@ palette_rgb = dict((
       [195, 229, 244],
       [220, 246, 239],
       [255, 255, 255]]),
-    ('perceptual_rainbow',
+    ('perceptual_rainbow_16',
      # Similar to Matteo Niccoli's Perceptual Rainbow:
      # http://mycarta.wordpress.com/2013/02/21/perceptual-rainbow-palette-the-method/
      # https://github.com/jradavenport/cubehelix
@@ -112,7 +112,7 @@ palette_rgb = dict((
       [161, 227, 95],
       [198, 220, 100],
       [233, 213, 117]]),
-    ('purple',
+    ('purple_16',
      # dict(start=0., rotation=0.0, n=16)
      [[0, 0, 0],
       [15, 14, 35],
@@ -130,7 +130,7 @@ palette_rgb = dict((
       [218, 215, 255],
       [236, 235, 255],
       [255, 255, 255]]),
-    ('jim_special',
+    ('jim_special_16',
      # http://www.ifweassume.com/2014/04/cubehelix-colormap-for-python.html
      # dict(start=0.3, rotation=-0.5, n=16)
      [[0, 0, 0],
@@ -149,7 +149,7 @@ palette_rgb = dict((
       [195, 237, 203],
       [226, 246, 225],
       [255, 255, 255]]),
-    ('red',
+    ('red_16',
      # http://www.ifweassume.com/2014/04/cubehelix-colormap-for-python.html
      # dict(start=0., rotation=0.5, n=16)
      [[0, 0, 0],
@@ -168,7 +168,7 @@ palette_rgb = dict((
       [236, 219, 189],
       [242, 238, 219],
       [255, 255, 255]]),
-    ('cubehelix1',
+    ('cubehelix1_16',
      # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
      # dict(gamma=1.0, start=1.5, rotation=-1.0, sat=1.5, n=16)
      [[0, 0, 0],
@@ -187,7 +187,7 @@ palette_rgb = dict((
       [193, 240, 191],
       [230, 245, 216],
       [255, 255, 255]]),
-    ('cubehelix2',
+    ('cubehelix2_16',
      # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
      # dict(gamma=1.0, start=2.0, rotation=1.0, sat=1.5, n=16)
      [[0, 0, 0],
@@ -206,7 +206,7 @@ palette_rgb = dict((
       [216, 231, 178],
       [226, 247, 219],
       [255, 255, 255]]),
-    ('cubehelix3',
+    ('cubehelix3_16',
      # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
      # dict(gamma=1.0, start=2.0, rotation=1.0, sat=3, n=16)
      [[0, 0, 0],

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -43,7 +43,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 from __future__ import absolute_import, print_function
-from collections import OrderedDict
 
 import numpy as np
 
@@ -54,33 +53,173 @@ url = 'http://adsabs.harvard.edu/abs/2011arXiv1108.5083G'
 palette_type = 'sequential'
 
 
-maps = OrderedDict((
+palette_names = [
+    'classic',
+    'perceptual_rainbow',
+    'purple',
+    'jim_special',
+    'red',
+    'cubehelix1',
+    'cubehelix2',
+    'cubehelix3'
+]
+
+
+palette_rgb = dict((
     ('classic',
-     dict(start=0.5, rotation=-1.5, gamma=1.0, sat=1.2,
-          min_light=0., max_light=1.,)),
+     # dict(start=0.5, rotation=-1.5, gamma=1.0, sat=1.2,
+     #      min_light=0., max_light=1., n=16)
+     [[0, 0, 0],
+      [22, 10, 34],
+      [24, 32, 68],
+      [16, 62, 83],
+      [14, 94, 74],
+      [35, 116, 51],
+      [80, 125, 35],
+      [138, 122, 45],
+      [190, 117, 85],
+      [218, 121, 145],
+      [219, 138, 203],
+      [204, 167, 240],
+      [191, 201, 251],
+      [195, 229, 244],
+      [220, 246, 239],
+      [255, 255, 255]]),
     ('perceptual_rainbow',
      # Similar to Matteo Niccoli's Perceptual Rainbow:
      # http://mycarta.wordpress.com/2013/02/21/perceptual-rainbow-palette-the-method/
      # https://github.com/jradavenport/cubehelix
-     dict(start_hue=240., end_hue=-300., min_sat=1., max_sat=2.5,
-          min_light=0.3, max_light=0.8, gamma=.9)),
+     # dict(start_hue=240., end_hue=-300., min_sat=1., max_sat=2.5,
+     #      min_light=0.3, max_light=0.8, gamma=.9, n=16)
+     [[135, 59, 97],
+      [143, 64, 127],
+      [143, 72, 157],
+      [135, 85, 185],
+      [121, 102, 207],
+      [103, 123, 220],
+      [84, 146, 223],
+      [69, 170, 215],
+      [59, 192, 197],
+      [60, 210, 172],
+      [71, 223, 145],
+      [93, 229, 120],
+      [124, 231, 103],
+      [161, 227, 95],
+      [198, 220, 100],
+      [233, 213, 117]]),
     ('purple',
-     dict(start=0., rotation=0.0)),
+     # dict(start=0., rotation=0.0, n=16)
+     [[0, 0, 0],
+      [15, 14, 35],
+      [31, 28, 68],
+      [47, 43, 99],
+      [63, 59, 127],
+      [79, 75, 152],
+      [96, 91, 174],
+      [113, 107, 194],
+      [130, 124, 211],
+      [147, 142, 225],
+      [164, 160, 237],
+      [182, 178, 246],
+      [200, 196, 252],
+      [218, 215, 255],
+      [236, 235, 255],
+      [255, 255, 255]]),
     ('jim_special',
      # http://www.ifweassume.com/2014/04/cubehelix-colormap-for-python.html
-     dict(start=0.3, rotation=-0.5)),
+     # dict(start=0.3, rotation=-0.5, n=16)
+     [[0, 0, 0],
+      [22, 10, 34],
+      [37, 25, 68],
+      [47, 43, 99],
+      [52, 65, 125],
+      [55, 88, 146],
+      [59, 112, 160],
+      [64, 137, 169],
+      [74, 160, 173],
+      [89, 181, 175],
+      [109, 199, 177],
+      [134, 214, 180],
+      [163, 227, 189],
+      [195, 237, 203],
+      [226, 246, 225],
+      [255, 255, 255]]),
     ('red',
      # http://www.ifweassume.com/2014/04/cubehelix-colormap-for-python.html
-     dict(start=0., rotation=0.5)),
+     # dict(start=0., rotation=0.5, n=16)
+     [[0, 0, 0],
+      [19, 12, 35],
+      [44, 22, 65],
+      [73, 32, 90],
+      [104, 41, 107],
+      [134, 53, 118],
+      [162, 67, 124],
+      [185, 83, 126],
+      [204, 102, 128],
+      [216, 124, 130],
+      [225, 148, 136],
+      [229, 172, 147],
+      [232, 196, 164],
+      [236, 219, 189],
+      [242, 238, 219],
+      [255, 255, 255]]),
     ('cubehelix1',
      # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
-     dict(gamma=1.0, start=1.5, rotation=-1.0, sat=1.5)),
+     # dict(gamma=1.0, start=1.5, rotation=-1.0, sat=1.5, n=16)
+     [[0, 0, 0],
+      [27, 15, 0],
+      [65, 23, 4],
+      [104, 27, 32],
+      [133, 33, 75],
+      [147, 45, 126],
+      [144, 66, 175],
+      [129, 96, 210],
+      [111, 131, 227],
+      [99, 166, 226],
+      [101, 197, 211],
+      [120, 219, 194],
+      [153, 233, 185],
+      [193, 240, 191],
+      [230, 245, 216],
+      [255, 255, 255]]),
     ('cubehelix2',
      # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
-     dict(gamma=1.0, start=2.0, rotation=1.0, sat=1.5)),
+     # dict(gamma=1.0, start=2.0, rotation=1.0, sat=1.5, n=16)
+     [[0, 0, 0],
+      [0, 28, 14],
+      [0, 51, 47],
+      [7, 65, 91],
+      [35, 71, 135],
+      [78, 72, 168],
+      [129, 72, 184],
+      [177, 77, 181],
+      [214, 90, 165],
+      [235, 113, 143],
+      [238, 142, 128],
+      [230, 175, 127],
+      [219, 206, 144],
+      [216, 231, 178],
+      [226, 247, 219],
+      [255, 255, 255]]),
     ('cubehelix3',
      # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
-     dict(gamma=1.0, start=2.0, rotation=1.0, sat=3)),
+     # dict(gamma=1.0, start=2.0, rotation=1.0, sat=3, n=16)
+     [[0, 0, 0],
+      [0, 39, 12],
+      [0, 68, 60],
+      [0, 80, 131],
+      [3, 75, 202],
+      [72, 60, 252],
+      [156, 43, 255],
+      [235, 36, 244],
+      [255, 45, 194],
+      [255, 73, 134],
+      [255, 115, 86],
+      [255, 164, 67],
+      [235, 209, 85],
+      [211, 241, 135],
+      [215, 255, 200],
+      [255, 255, 255]]),
 ))
 
 
@@ -89,72 +228,74 @@ class Cubehelix(Palette):
     Representation of a Cubehelix color map with matplotlib compatible
     views of the map.
 
-    Parameters
-    ----------
-    name : str, optional
-        Name of the color map (defaults to ``'custom_cubehelix'``).
-    start : scalar, optional
-        Sets the starting position in the RGB color space. 0=blue, 1=red,
-        2=green. Default is ``0.5`` (purple).
-    rotation : scalar, optional
-        The number of rotations through the rainbow. Can be positive
-        or negative, indicating direction of rainbow. Negative values
-        correspond to Blue->Red direction. Default is ``-1.5``.
-    start_hue : scalar, optional
-        Sets the starting color, ranging from [-360, 360]. Combined with
-        `end_hue`, this parameter overrides ``start`` and ``rotation``.
-        This parameter is based on the D3 implementation by @mbostock.
-        Default is ``None``.
-    end_hue : scalar, optional
-        Sets the ending color, ranging from [-360, 360]. Combined with
-        `start_hue`, this parameter overrides ``start`` and ``rotation``.
-        This parameter is based on the D3 implementation by @mbostock.
-        Default is ``None``.
-    gamma : scalar, optional
-        The gamma correction for intensity. Values of ``gamma < 1`` emphasize
-        low intensities while ``gamma > 1`` emphasises high intensities.
-        Default is ``1.0``.
-    sat : scalar, optional
-        The uniform saturation intensity factor. ``sat=0`` produces grayscale,
-        while ``sat=1`` retains the full saturation. Setting ``sat>1``
-        oversaturates the color map, at the risk of clipping the color scale.
-        Note that ``sat`` overrides both ``min_stat`` and ``max_sat`` if set.
-    min_sat : scalar, optional
-        Saturation at the minimum level. Default is ``1.2``.
-    max_sat : scalar, optional
-        Satuation at the maximum level. Default is ``1.2``.
-    min_light : scalar, optional
-        Minimum lightness value. Default is ``0``.
-    max_light : scalar, optional
-        Maximum lightness value. Default is ``1``.
-    n : scalar, optional
-        Number of discrete rendered colors. Default is ``256``.
-    reverse : bool, optional
-        Set to ``True`` to reverse the color map. Will go from black to
-        white. Good for density plots where shade -> density.
-        Default is ``False``.
-
     """
     url = url
 
-    def __init__(self, name="custom_cubehelix", **kwargs):
-        colors = Cubehelix._cubehelix(**kwargs)
+    def __init__(self, name, colors):
         super(Cubehelix, self).__init__(name, palette_type, colors)
 
-    @staticmethod
-    def _cubehelix(start=0.5, rotation=-1.5, gamma=1.0,
-                   start_hue=None, end_hue=None,
-                   sat=None, min_sat=1.2, max_sat=1.2,
-                   min_light=0., max_light=1.,
-                   n=256., reverse=False):
+    @classmethod
+    def make(cls, start=0.5, rotation=-1.5, gamma=1.0,
+             start_hue=None, end_hue=None,
+             sat=None, min_sat=1.2, max_sat=1.2,
+             min_light=0., max_light=1.,
+             n=256., reverse=False, name='custom_cubehelix'):
         """
-        Create a sequence of RGB colours given cubehelix algorithm parameters.
+        Create an arbitrary Cubehelix color palette from the algorithm.
 
         See http://adsabs.harvard.edu/abs/2011arXiv1108.5083G for a technical
         explanation of the algorithm.
 
-        Returns a list of 3-lists corresponding to RGB colors in the map.
+        Parameters
+        ----------
+        start : scalar, optional
+            Sets the starting position in the RGB color space. 0=blue, 1=red,
+            2=green. Default is ``0.5`` (purple).
+        rotation : scalar, optional
+            The number of rotations through the rainbow. Can be positive
+            or negative, indicating direction of rainbow. Negative values
+            correspond to Blue->Red direction. Default is ``-1.5``.
+        start_hue : scalar, optional
+            Sets the starting color, ranging from [-360, 360]. Combined with
+            `end_hue`, this parameter overrides ``start`` and ``rotation``.
+            This parameter is based on the D3 implementation by @mbostock.
+            Default is ``None``.
+        end_hue : scalar, optional
+            Sets the ending color, ranging from [-360, 360]. Combined with
+            `start_hue`, this parameter overrides ``start`` and ``rotation``.
+            This parameter is based on the D3 implementation by @mbostock.
+            Default is ``None``.
+        gamma : scalar, optional
+            The gamma correction for intensity. Values of ``gamma < 1``
+            emphasize low intensities while ``gamma > 1`` emphasises high
+            intensities. Default is ``1.0``.
+        sat : scalar, optional
+            The uniform saturation intensity factor. ``sat=0`` produces
+            grayscale, while ``sat=1`` retains the full saturation. Setting
+            ``sat>1`` oversaturates the color map, at the risk of clipping
+            the color scale. Note that ``sat`` overrides both ``min_stat``
+            and ``max_sat`` if set.
+        min_sat : scalar, optional
+            Saturation at the minimum level. Default is ``1.2``.
+        max_sat : scalar, optional
+            Satuation at the maximum level. Default is ``1.2``.
+        min_light : scalar, optional
+            Minimum lightness value. Default is ``0``.
+        max_light : scalar, optional
+            Maximum lightness value. Default is ``1``.
+        n : scalar, optional
+            Number of discrete rendered colors. Default is ``256``.
+        reverse : bool, optional
+            Set to ``True`` to reverse the color map. Will go from black to
+            white. Good for density plots where shade -> density.
+            Default is ``False``.
+        name : str, optional
+            Name of the color map (defaults to ``'custom_cubehelix'``).
 
+        Returns
+        -------
+        palette : `Cubehelix`
+            A Cubehelix color palette.
         """
         # start_hue/end_hue were popularized by D3's implementation
         # and will override start/rotation if set
@@ -194,7 +335,8 @@ class Cubehelix(Palette):
         if reverse:
             rgb = rgb[::-1, :]
 
-        return rgb.astype(int).tolist()
+        colors = rgb.astype(int).tolist()
+        return cls(name, colors)
 
 
 def print_maps():
@@ -202,10 +344,10 @@ def print_maps():
     Print a list of pre-made Cubehelix palettes.
 
     """
-    namelen = max(len(name) for name in maps.keys())
+    namelen = max(len(name) for name in palette_names)
     fmt = '{0:' + str(namelen + 4) + '}{1:16}'
 
-    for i, name in enumerate(maps.keys()):
+    for name in palette_names:
         print(fmt.format(name, palette_type))
 
 
@@ -230,15 +372,20 @@ def get_map(name, n=256, reverse=False):
 
     """
     try:
-        cubehelix_params = maps[name.lower()]
+        # Make everthing lower case for matching
+        index = [s.lower() for s in palette_names].index(name.lower())
     except KeyError:
         msg = "{0!r} is an unknown CubeHelix palette."
         raise KeyError(msg.format(name))
 
-    if reverse:
-        name = name + '_r'
+    real_name = palette_names[index]
+    colors = palette_rgb[real_name]
 
-    return Cubehelix(name=name.lower(), reverse=reverse, **cubehelix_params)
+    if reverse:
+        real_name = real_name + '_r'
+        colors = list(reversed(colors))
+
+    return Cubehelix(real_name, colors)
 
 
 def _get_all_maps():
@@ -248,8 +395,8 @@ def _get_all_maps():
     These default palettes are rendered with 256 colours, making them useful
     for continuous maps.
     """
-    d = OrderedDict()
-    for name in maps.keys():
+    d = {}
+    for name in palette_names:
         d[name] = get_map(name)
         d[name + '_r'] = get_map(name, reverse=True)
     return d

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -376,7 +376,7 @@ def print_maps():
         print(fmt.format(name, palette_type))
 
 
-def get_map(name, reverse=False, **kwargs):
+def get_map(name, reverse=False):
     """
     Get a pre-made Cubehelix palette by name.
 
@@ -392,9 +392,6 @@ def get_map(name, reverse=False, **kwargs):
     palette : Cubehelix
 
     """
-    for key in kwargs:
-        print('palettable.cubehelix.get_map() does not use `{0}`'.format(key))
-
     try:
         # Make everthing lower case for matching
         index = [s.lower() for s in palette_names].index(name.lower())

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -381,8 +381,8 @@ def get_map(name, n=256, reverse=False):
     try:
         # Make everthing lower case for matching
         index = [s.lower() for s in palette_names].index(name.lower())
-    except KeyError:
-        msg = "{0!r} is an unknown CubeHelix palette."
+    except ValueError:
+        msg = "{0!r} is an unknown Cubehelix palette."
         raise KeyError(msg.format(name))
 
     real_name = palette_names[index]

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -43,6 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 from __future__ import absolute_import, print_function
+from collections import OrderedDict
 
 import numpy as np
 
@@ -51,6 +52,36 @@ from ..palette import Palette
 
 url = 'http://adsabs.harvard.edu/abs/2011arXiv1108.5083G'
 palette_type = 'sequential'
+
+
+maps = OrderedDict((
+    ('classic',
+     dict(start=0.5, rotation=-1.5, gamma=1.0, sat=1.2,
+          min_light=0., max_light=1.,)),
+    ('perceptual_rainbow',
+     # Similar to Matteo Niccoli's Perceptual Rainbow:
+     # http://mycarta.wordpress.com/2013/02/21/perceptual-rainbow-palette-the-method/
+     # https://github.com/jradavenport/cubehelix
+     dict(start_hue=240., end_hue=-300., min_sat=1., max_sat=2.5,
+          min_light=0.3, max_light=0.8, gamma=.9)),
+    ('purple',
+     dict(start=0., rotation=0.0)),
+    ('jim_special',
+     # http://www.ifweassume.com/2014/04/cubehelix-colormap-for-python.html
+     dict(start=0.3, rotation=-0.5)),
+    ('red',
+     # http://www.ifweassume.com/2014/04/cubehelix-colormap-for-python.html
+     dict(start=0., rotation=0.5)),
+    ('cubehelix1',
+     # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
+     dict(gamma=1.0, start=1.5, rotation=-1.0, sat=1.5)),
+    ('cubehelix2',
+     # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
+     dict(gamma=1.0, start=2.0, rotation=1.0, sat=1.5)),
+    ('cubehelix3',
+     # http://nbviewer.ipython.org/gist/anonymous/a4fa0adb08f9e9ea4f94
+     dict(gamma=1.0, start=2.0, rotation=1.0, sat=3)),
+))
 
 
 class Cubehelix(Palette):
@@ -164,3 +195,61 @@ class Cubehelix(Palette):
             rgb = rgb[::-1, :]
 
         return rgb
+
+
+def print_maps():
+    """
+    Print a list of pre-made Cubehelix palettes.
+
+    """
+    namelen = max(len(name) for name in maps.keys())
+    fmt = '{0:' + str(namelen + 4) + '}{1:16}'
+
+    for i, name in enumerate(maps.keys()):
+        print(fmt.format(name, palette_type))
+
+
+def get_map(name, n=256, reverse=False):
+    """
+    Get a pre-made Cubehelix palette by name.
+
+    Parameters
+    ----------
+    name : str
+        Name of map. Use `print_maps` to see available names. If `None`, then
+        return a list of all colormaps.
+    n : int, optional
+        Number of colours in the palette. Default is ``256``, useful for
+        making continuous color maps.
+    reverse : bool, optional
+        If True reverse colors from their default order.
+
+    Returns
+    -------
+    palette : Cubehelix
+
+    """
+    try:
+        cubehelix_params = maps[name.lower()]
+    except KeyError:
+        msg = "{0!r} is an unknown CubeHelix palette."
+        raise KeyError(msg.format(name))
+
+    if reverse:
+        name = name + '_r'
+
+    return Cubehelix(name=name.lower(), reverse=reverse, **cubehelix_params)
+
+
+def _get_all_maps():
+    """
+    Returns a dictionary of all Cubehelix palettes, including reversed ones.
+
+    These default palettes are rendered with 256 colours, making them useful
+    for continuous maps.
+    """
+    d = OrderedDict()
+    for name in maps.keys():
+        d[name] = get_map(name)
+        d[name + '_r'] = get_map(name, reverse=True)
+    return d

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -1,0 +1,178 @@
+# coding: utf-8
+"""
+Cubehelix color maps and palettes.
+
+The Cubehelix algorithm makes color scales with monotonic changes in percieved
+brightness. This means that a cubehelix color map automatically transforms to
+a monotonic grayscale color map when rendered without color.
+
+Cubehelix maps are generated algorithmically, giving the user flexibility
+in desiging a color map that is also safe for grayscale printers. This
+module provides several cubehelix realizations, while also exposing the
+algorithm directly through the :class:`Cubehelix` class.
+
+Cubehelix was developed by `D.A Green, 2011, BASI, 39, 289
+<http://adsabs.harvard.edu/abs/2011arXiv1108.5083G>`_. The original Python
+port was done by James R. A. Davenport (see License).
+
+Original License
+----------------
+
+Copyright (c) 2014, James R. A. Davenport and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+from matplotlib.colors import LinearSegmentedColormap as LSC
+from math import pi
+import numpy as np
+
+
+def cmap(start=0.5, rot=-1.5, gamma=1.0, reverse=False, nlev=256.,
+         minSat=1.2, maxSat=1.2, minLight=0., maxLight=1.,
+         **kwargs):
+    """
+    A full implementation of Dave Green's "cubehelix" for Matplotlib.
+    Based on the FORTRAN 77 code provided in
+    D.A. Green, 2011, BASI, 39, 289.
+
+    http://adsabs.harvard.edu/abs/2011arXiv1108.5083G
+
+    User can adjust all parameters of the cubehelix algorithm.
+    This enables much greater flexibility in choosing color maps, while
+    always ensuring the color map scales in intensity from black
+    to white. A few simple examples:
+
+    Default color map settings produce the standard "cubehelix".
+
+    Create color map in only blues by setting rot=0 and start=0.
+
+    Create reverse (white to black) backwards through the rainbow once
+    by setting rot=1 and reverse=True.
+
+    Parameters
+    ----------
+    start : scalar, optional
+        Sets the starting position in the color space. 0=blue, 1=red,
+        2=green. Defaults to 0.5.
+    rot : scalar, optional
+        The number of rotations through the rainbow. Can be positive
+        or negative, indicating direction of rainbow. Negative values
+        correspond to Blue->Red direction. Defaults to -1.5
+    gamma : scalar, optional
+        The gamma correction for intensity. Defaults to 1.0
+    reverse : boolean, optional
+        Set to True to reverse the color map. Will go from black to
+        white. Good for density plots where shade~density. Defaults to False
+    nlev : scalar, optional
+        Defines the number of discrete levels to render colors at.
+        Defaults to 256.
+    sat : scalar, optional
+        The saturation intensity factor. Defaults to 1.2
+        NOTE: this was formerly known as "hue" parameter
+    minSat : scalar, optional
+        Sets the minimum-level saturation. Defaults to 1.2
+    maxSat : scalar, optional
+        Sets the maximum-level saturation. Defaults to 1.2
+    startHue : scalar, optional
+        Sets the starting color, ranging from [0, 360], as in
+        D3 version by @mbostock
+        NOTE: overrides values in start parameter
+    endHue : scalar, optional
+        Sets the ending color, ranging from [0, 360], as in
+        D3 version by @mbostock
+        NOTE: overrides values in rot parameter
+    minLight : scalar, optional
+        Sets the minimum lightness value. Defaults to 0.
+    maxLight : scalar, optional
+        Sets the maximum lightness value. Defaults to 1.
+
+    Returns
+    -------
+    matplotlib.colors.LinearSegmentedColormap object
+
+    Example
+    -------
+    >>> import cubehelix
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.random.randn(1000)
+    >>> y = np.random.randn(1000)
+    >>> cx = cubehelix.cmap(start=0., rot=-0.5)
+    >>> plt.hexbin(x, y, gridsize=50, cmap=cx)
+
+    Revisions
+    ---------
+    2014-04 (@jradavenport) Ported from IDL version
+    2014-04 (@jradavenport) Added kwargs to enable similar to D3 version,
+                            changed name of "hue" parameter to "sat"
+    """
+
+# override start and rot if startHue and endHue are set
+    if kwargs is not None:
+        if 'startHue' in kwargs:
+            start = (kwargs.get('startHue') / 360. - 1.) * 3.
+        if 'endHue' in kwargs:
+            rot = kwargs.get('endHue') / 360. - start / 3. - 1.
+        if 'sat' in kwargs:
+            minSat = kwargs.get('sat')
+            maxSat = kwargs.get('sat')
+
+# set up the parameters
+    fract = np.linspace(minLight, maxLight, nlev)
+    angle = 2.0 * pi * (start / 3.0 + rot * fract + 1.)
+    fract = fract**gamma
+
+    satar = np.linspace(minSat, maxSat, nlev)
+    amp = satar * fract * (1. - fract) / 2.
+
+# compute the RGB vectors according to main equations
+    red = fract + amp * (-0.14861 * np.cos(angle) + 1.78277 * np.sin(angle))
+    grn = fract + amp * (-0.29227 * np.cos(angle) - 0.90649 * np.sin(angle))
+    blu = fract + amp * (1.97294 * np.cos(angle))
+
+# find where RBB are outside the range [0,1], clip
+    red[np.where((red > 1.))] = 1.
+    grn[np.where((grn > 1.))] = 1.
+    blu[np.where((blu > 1.))] = 1.
+
+    red[np.where((red < 0.))] = 0.
+    grn[np.where((grn < 0.))] = 0.
+    blu[np.where((blu < 0.))] = 0.
+
+# optional color reverse
+    if reverse is True:
+        red = red[::-1]
+        blu = blu[::-1]
+        grn = grn[::-1]
+
+# put in to tuple & dictionary structures needed
+    rr = []
+    bb = []
+    gg = []
+    for k in range(0, int(nlev)):
+        rr.append((float(k) / (nlev - 1.), red[k], red[k]))
+        bb.append((float(k) / (nlev - 1.), blu[k], blu[k]))
+        gg.append((float(k) / (nlev - 1.), grn[k], grn[k]))
+
+    cdict = {'red': rr, 'blue': bb, 'green': gg}
+    return LSC('cubehelix_map', cdict)

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -358,18 +358,14 @@ def print_maps():
         print(fmt.format(name, palette_type))
 
 
-def get_map(name, n=256, reverse=False):
+def get_map(name, reverse=False, **kwargs):
     """
     Get a pre-made Cubehelix palette by name.
 
     Parameters
     ----------
     name : str
-        Name of map. Use `print_maps` to see available names. If `None`, then
-        return a list of all colormaps.
-    n : int, optional
-        Number of colours in the palette. Default is ``256``, useful for
-        making continuous color maps.
+        Name of map. Use `print_maps()` to see available names.
     reverse : bool, optional
         If True reverse colors from their default order.
 
@@ -378,6 +374,9 @@ def get_map(name, n=256, reverse=False):
     palette : Cubehelix
 
     """
+    for key in kwargs:
+        print('palettable.cubehelix.get_map() does not use `{0}`'.format(key))
+
     try:
         # Make everthing lower case for matching
         index = [s.lower() for s in palette_names].index(name.lower())
@@ -399,8 +398,8 @@ def _get_all_maps():
     """
     Returns a dictionary of all Cubehelix palettes, including reversed ones.
 
-    These default palettes are rendered with 256 colours, making them useful
-    for continuous maps.
+    These default palettes are rendered with 16 colours.
+
     """
     d = {}
     for name in palette_names:

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -44,7 +44,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 from __future__ import absolute_import, print_function
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover
+    HAVE_NPY = False
+else:
+    HAVE_NPY = True
 
 from ..palette import Palette
 
@@ -297,6 +302,8 @@ class Cubehelix(Palette):
         palette : `Cubehelix`
             A Cubehelix color palette.
         """
+        if not HAVE_NPY:  # pragma: no cover
+            raise RuntimeError('numpy not available.')
         # start_hue/end_hue were popularized by D3's implementation
         # and will override start/rotation if set
         if start_hue is not None and end_hue is not None:

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -153,7 +153,7 @@ class Cubehelix(Palette):
         See http://adsabs.harvard.edu/abs/2011arXiv1108.5083G for a technical
         explanation of the algorithm.
 
-        Returns a (n, 3) array of colour values, scaled from 0 to 255.
+        Returns a list of 3-lists corresponding to RGB colors in the map.
 
         """
         # start_hue/end_hue were popularized by D3's implementation
@@ -194,7 +194,7 @@ class Cubehelix(Palette):
         if reverse:
             rgb = rgb[::-1, :]
 
-        return rgb
+        return rgb.astype(int).tolist()
 
 
 def print_maps():

--- a/palettable/cubehelix/cubehelix.py
+++ b/palettable/cubehelix/cubehelix.py
@@ -42,32 +42,21 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
-from matplotlib.colors import LinearSegmentedColormap as LSC
-from math import pi
+from __future__ import absolute_import, print_function
+
 import numpy as np
 
+from ..palette import Palette
 
-def cmap(start=0.5, rot=-1.5, gamma=1.0, reverse=False, nlev=256.,
-         minSat=1.2, maxSat=1.2, minLight=0., maxLight=1.,
-         **kwargs):
+
+url = 'http://adsabs.harvard.edu/abs/2011arXiv1108.5083G'
+palette_type = 'sequential'
+
+
+class Cubehelix(Palette):
     """
-    A full implementation of Dave Green's "cubehelix" for Matplotlib.
-    Based on the FORTRAN 77 code provided in
-    D.A. Green, 2011, BASI, 39, 289.
-
-    http://adsabs.harvard.edu/abs/2011arXiv1108.5083G
-
-    User can adjust all parameters of the cubehelix algorithm.
-    This enables much greater flexibility in choosing color maps, while
-    always ensuring the color map scales in intensity from black
-    to white. A few simple examples:
-
-    Default color map settings produce the standard "cubehelix".
-
-    Create color map in only blues by setting rot=0 and start=0.
-
-    Create reverse (white to black) backwards through the rainbow once
-    by setting rot=1 and reverse=True.
+    Representation of a Cubehelix color map with matplotlib compatible
+    views of the map.
 
     Parameters
     ----------
@@ -105,74 +94,59 @@ def cmap(start=0.5, rot=-1.5, gamma=1.0, reverse=False, nlev=256.,
         Sets the minimum lightness value. Defaults to 0.
     maxLight : scalar, optional
         Sets the maximum lightness value. Defaults to 1.
-
-    Returns
-    -------
-    matplotlib.colors.LinearSegmentedColormap object
-
-    Example
-    -------
-    >>> import cubehelix
-    >>> import matplotlib.pyplot as plt
-    >>> import numpy as np
-    >>> x = np.random.randn(1000)
-    >>> y = np.random.randn(1000)
-    >>> cx = cubehelix.cmap(start=0., rot=-0.5)
-    >>> plt.hexbin(x, y, gridsize=50, cmap=cx)
-
-    Revisions
-    ---------
-    2014-04 (@jradavenport) Ported from IDL version
-    2014-04 (@jradavenport) Added kwargs to enable similar to D3 version,
-                            changed name of "hue" parameter to "sat"
     """
+    url = url
 
-# override start and rot if startHue and endHue are set
-    if kwargs is not None:
-        if 'startHue' in kwargs:
-            start = (kwargs.get('startHue') / 360. - 1.) * 3.
-        if 'endHue' in kwargs:
-            rot = kwargs.get('endHue') / 360. - start / 3. - 1.
-        if 'sat' in kwargs:
-            minSat = kwargs.get('sat')
-            maxSat = kwargs.get('sat')
+    def __init__(self, name="custom_cubehelix", **kwargs):
+        colors = Cubehelix._cubehelix(**kwargs)
+        super(Cubehelix, self).__init__(name, palette_type, colors)
 
-# set up the parameters
-    fract = np.linspace(minLight, maxLight, nlev)
-    angle = 2.0 * pi * (start / 3.0 + rot * fract + 1.)
-    fract = fract**gamma
+    @staticmethod
+    def _cubehelix(start=0.5, rot=-1.5, gamma=1.0, reverse=False, nlev=256.,
+                   minSat=1.2, maxSat=1.2, minLight=0., maxLight=1., **kwargs):
+        """
+        Create a sequence of RGB colours given cubehelix algorithm parameters.
 
-    satar = np.linspace(minSat, maxSat, nlev)
-    amp = satar * fract * (1. - fract) / 2.
+        """
+        # override start and rot if startHue and endHue are set
+        if kwargs is not None:
+            if 'startHue' in kwargs:
+                start = (kwargs.get('startHue') / 360. - 1.) * 3.
+            if 'endHue' in kwargs:
+                rot = kwargs.get('endHue') / 360. - start / 3. - 1.
+            if 'sat' in kwargs:
+                minSat = kwargs.get('sat')
+                maxSat = kwargs.get('sat')
 
-# compute the RGB vectors according to main equations
-    red = fract + amp * (-0.14861 * np.cos(angle) + 1.78277 * np.sin(angle))
-    grn = fract + amp * (-0.29227 * np.cos(angle) - 0.90649 * np.sin(angle))
-    blu = fract + amp * (1.97294 * np.cos(angle))
+        # set up the parameters
+        fract = np.linspace(minLight, maxLight, nlev)
+        angle = 2.0 * np.pi * (start / 3.0 + rot * fract + 1.)
+        fract = fract**gamma
 
-# find where RBB are outside the range [0,1], clip
-    red[np.where((red > 1.))] = 1.
-    grn[np.where((grn > 1.))] = 1.
-    blu[np.where((blu > 1.))] = 1.
+        satar = np.linspace(minSat, maxSat, nlev)
+        amp = satar * fract * (1. - fract) / 2.
 
-    red[np.where((red < 0.))] = 0.
-    grn[np.where((grn < 0.))] = 0.
-    blu[np.where((blu < 0.))] = 0.
+        # compute the RGB vectors according to main equations
+        cos_angle = np.cos(angle)
+        sin_angle = np.sin(angle)
+        red = fract + amp * (-0.14861 * cos_angle + 1.78277 * sin_angle)
+        grn = fract + amp * (-0.29227 * cos_angle - 0.90649 * sin_angle)
+        blu = fract + amp * (1.97294 * cos_angle)
 
-# optional color reverse
-    if reverse is True:
-        red = red[::-1]
-        blu = blu[::-1]
-        grn = grn[::-1]
+        # find where RBB are outside the range [0,1], clip
+        red[np.where((red > 1.))] = 1.
+        grn[np.where((grn > 1.))] = 1.
+        blu[np.where((blu > 1.))] = 1.
 
-# put in to tuple & dictionary structures needed
-    rr = []
-    bb = []
-    gg = []
-    for k in range(0, int(nlev)):
-        rr.append((float(k) / (nlev - 1.), red[k], red[k]))
-        bb.append((float(k) / (nlev - 1.), blu[k], blu[k]))
-        gg.append((float(k) / (nlev - 1.), grn[k], grn[k]))
+        red[np.where((red < 0.))] = 0.
+        grn[np.where((grn < 0.))] = 0.
+        blu[np.where((blu < 0.))] = 0.
 
-    cdict = {'red': rr, 'blue': bb, 'green': gg}
-    return LSC('cubehelix_map', cdict)
+        # optional color reverse
+        if reverse is True:
+            red = red[::-1]
+            blu = blu[::-1]
+            grn = grn[::-1]
+
+        colors = zip(red * 255., grn * 255., blu * 255.)
+        return colors

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -17,6 +17,12 @@ def test_print_maps(capsys):
     assert out
 
 
+def test_unused_get_map_arg(capsys):
+    cubehelix.get_map('classic', n=16)
+    out, err = capsys.readouterr()
+    assert out == 'palettable.cubehelix.get_map() does not use `n`\n'
+
+
 def test_get_map():
     palette = cubehelix.get_map('CLASSIC')
     assert palette.name == 'classic'

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -17,12 +17,6 @@ def test_print_maps(capsys):
     assert out
 
 
-def test_unused_get_map_arg(capsys):
-    cubehelix.get_map('classic', n=16)
-    out, err = capsys.readouterr()
-    assert out == 'palettable.cubehelix.get_map() does not use `n`\n'
-
-
 def test_get_map():
     palette = cubehelix.get_map('CLASSIC')
     assert palette.name == 'classic'

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -90,3 +90,12 @@ def test_cubehelix3():
     palette = cubehelix.Cubehelix.make(gamma=1.0, start=2.0, rotation=1.0,
                                        sat=3, n=16)
     assert palette.colors == cubehelix.get_map('cubehelix3').colors
+
+
+@pytest.mark.skipif('not HAVE_NPY')
+def test_hex_color():
+    palette = cubehelix.Cubehelix.make(start=0.5, rotation=-1.5, gamma=1.0,
+                                       sat=1.2, min_light=0., max_light=1.,
+                                       n=16)
+    for color in palette.hex_colors:
+        assert 'L' not in color

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -10,12 +10,24 @@ from ... import cubehelix
 HAVE_NPY = cubehelix.cubehelix.HAVE_NPY
 
 
+def test_print_maps(capsys):
+    # just make sure there are no errors
+    cubehelix.print_maps()
+    out, err = capsys.readouterr()
+    assert out
+
+
 def test_get_map():
     palette = cubehelix.get_map('CLASSIC')
     assert palette.name == 'classic'
     assert palette.type == 'sequential'
     assert len(palette.colors) == 16
     assert palette.url == 'http://adsabs.harvard.edu/abs/2011arXiv1108.5083G'
+
+
+def test_get_map_bad_name():
+    with pytest.raises(KeyError):
+        cubehelix.get_map('bad name')
 
 
 def test_get_map_reversed():

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+
+# import numpy as np
+
+from ... import cubehelix
+
+
+def test_get_map():
+    palette = cubehelix.get_map('CLASSIC')
+    assert palette.name == 'classic'
+    assert palette.type == 'sequential'
+    assert len(palette.colors) == 256
+    assert palette.url == 'http://adsabs.harvard.edu/abs/2011arXiv1108.5083G'
+
+
+def test_get_map_reversed():
+    palette = cubehelix.get_map('classic', reverse=False)
+    palette_r = cubehelix.get_map('classic', reverse=True)
+    assert palette.hex_colors[0] == palette_r.hex_colors[-1]
+
+
+def test_palettes_loaded():
+    assert isinstance(cubehelix.classic, cubehelix.Cubehelix)
+    assert isinstance(cubehelix.classic_r, cubehelix.Cubehelix)
+
+
+def test_default_is_classic():
+    classic_palette = cubehelix.get_map('classic')
+    default_palette = cubehelix.Cubehelix(n=256)
+    assert classic_palette.hex_colors[0] == default_palette.hex_colors[0]
+    assert classic_palette.hex_colors[128] == default_palette.hex_colors[128]
+    assert classic_palette.hex_colors[255] == default_palette.hex_colors[255]
+    # Test consistency
+    known_colors = ['#0L0L0L', '#23L74L33L', '#DBL8ALCBL', '#FFLFFLFFL']
+    palette = cubehelix.Cubehelix(n=4)
+    for c1, c2 in zip(palette.hex_colors, known_colors):
+        assert c1 == c2
+
+
+def test_start_end_hue():
+    # Test to make sure result is consistent
+    palette = cubehelix.Cubehelix(start_hue=240., end_hue=-300.,
+                                  min_sat=1., max_sat=2.5,
+                                  min_light=0.3, max_light=0.8, gamma=.9, n=4)
+    known_colors = ['#87L3BL61L', '#67L7BLDCL', '#47LDFL91L', '#E9LD5L75L']
+    for c1, c2 in zip(palette.hex_colors, known_colors):
+        assert c1 == c2

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -36,6 +36,12 @@ def test_get_map_reversed():
     assert palette.colors == palette_r.colors[::-1]
 
 
+def test_make_map_reversed():
+    palette = cubehelix.Cubehelix.make(n=16, reverse=False)
+    palette_r = cubehelix.Cubehelix.make(n=16, reverse=True)
+    assert palette.colors == palette_r.colors[::-1]
+
+
 def test_palettes_loaded():
     assert isinstance(cubehelix.classic_16, cubehelix.Cubehelix)
     assert isinstance(cubehelix.classic_16_r, cubehelix.Cubehelix)

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -18,8 +18,8 @@ def test_print_maps(capsys):
 
 
 def test_get_map():
-    palette = cubehelix.get_map('CLASSIC')
-    assert palette.name == 'classic'
+    palette = cubehelix.get_map('CLASSIC_16')
+    assert palette.name == 'classic_16'
     assert palette.type == 'sequential'
     assert len(palette.colors) == 16
     assert palette.url == 'http://adsabs.harvard.edu/abs/2011arXiv1108.5083G'
@@ -31,19 +31,19 @@ def test_get_map_bad_name():
 
 
 def test_get_map_reversed():
-    palette = cubehelix.get_map('classic', reverse=False)
-    palette_r = cubehelix.get_map('classic', reverse=True)
+    palette = cubehelix.get_map('classic_16', reverse=False)
+    palette_r = cubehelix.get_map('classic_16', reverse=True)
     assert palette.colors == palette_r.colors[::-1]
 
 
 def test_palettes_loaded():
-    assert isinstance(cubehelix.classic, cubehelix.Cubehelix)
-    assert isinstance(cubehelix.classic_r, cubehelix.Cubehelix)
+    assert isinstance(cubehelix.classic_16, cubehelix.Cubehelix)
+    assert isinstance(cubehelix.classic_16_r, cubehelix.Cubehelix)
 
 
 @pytest.mark.skipif('not HAVE_NPY')
 def test_default_is_classic():
-    classic_palette = cubehelix.get_map('classic')
+    classic_palette = cubehelix.get_map('classic_16')
     default_palette = cubehelix.Cubehelix.make(n=16)
     assert classic_palette.colors == default_palette.colors
 
@@ -53,7 +53,7 @@ def test_classic():
     palette = cubehelix.Cubehelix.make(start=0.5, rotation=-1.5, gamma=1.0,
                                        sat=1.2, min_light=0., max_light=1.,
                                        n=16)
-    assert palette.colors == cubehelix.get_map('classic').colors
+    assert palette.colors == cubehelix.get_map('classic_16').colors
 
 
 @pytest.mark.skipif('not HAVE_NPY')
@@ -62,46 +62,46 @@ def test_perceptual_rainbow():
                                        min_sat=1., max_sat=2.5,
                                        min_light=0.3, max_light=0.8, gamma=.9,
                                        n=16)
-    assert palette.colors == cubehelix.get_map('perceptual_rainbow').colors
+    assert palette.colors == cubehelix.get_map('perceptual_rainbow_16').colors
 
 
 @pytest.mark.skipif('not HAVE_NPY')
 def test_purple():
     palette = cubehelix.Cubehelix.make(start=0., rotation=0.0, n=16)
-    assert palette.colors == cubehelix.get_map('purple').colors
+    assert palette.colors == cubehelix.get_map('purple_16').colors
 
 
 @pytest.mark.skipif('not HAVE_NPY')
 def test_jim_special():
     palette = cubehelix.Cubehelix.make(start=0.3, rotation=-0.5, n=16)
-    assert palette.colors == cubehelix.get_map('jim_special').colors
+    assert palette.colors == cubehelix.get_map('jim_special_16').colors
 
 
 @pytest.mark.skipif('not HAVE_NPY')
 def test_red():
     palette = cubehelix.Cubehelix.make(start=0., rotation=0.5, n=16)
-    assert palette.colors == cubehelix.get_map('red').colors
+    assert palette.colors == cubehelix.get_map('red_16').colors
 
 
 @pytest.mark.skipif('not HAVE_NPY')
 def test_cubehelix1():
     palette = cubehelix.Cubehelix.make(gamma=1.0, start=1.5,
                                        rotation=-1.0, sat=1.5, n=16)
-    assert palette.colors == cubehelix.get_map('cubehelix1').colors
+    assert palette.colors == cubehelix.get_map('cubehelix1_16').colors
 
 
 @pytest.mark.skipif('not HAVE_NPY')
 def test_cubehelix2():
     palette = cubehelix.Cubehelix.make(gamma=1.0, start=2.0, rotation=1.0,
                                        sat=1.5, n=16)
-    assert palette.colors == cubehelix.get_map('cubehelix2').colors
+    assert palette.colors == cubehelix.get_map('cubehelix2_16').colors
 
 
 @pytest.mark.skipif('not HAVE_NPY')
 def test_cubehelix3():
     palette = cubehelix.Cubehelix.make(gamma=1.0, start=2.0, rotation=1.0,
                                        sat=3, n=16)
-    assert palette.colors == cubehelix.get_map('cubehelix3').colors
+    assert palette.colors == cubehelix.get_map('cubehelix3_16').colors
 
 
 @pytest.mark.skipif('not HAVE_NPY')

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -9,14 +9,14 @@ def test_get_map():
     palette = cubehelix.get_map('CLASSIC')
     assert palette.name == 'classic'
     assert palette.type == 'sequential'
-    assert len(palette.colors) == 256
+    assert len(palette.colors) == 16
     assert palette.url == 'http://adsabs.harvard.edu/abs/2011arXiv1108.5083G'
 
 
 def test_get_map_reversed():
     palette = cubehelix.get_map('classic', reverse=False)
     palette_r = cubehelix.get_map('classic', reverse=True)
-    assert palette.hex_colors[0] == palette_r.hex_colors[-1]
+    assert palette.colors == palette_r.colors[::-1]
 
 
 def test_palettes_loaded():
@@ -26,22 +26,53 @@ def test_palettes_loaded():
 
 def test_default_is_classic():
     classic_palette = cubehelix.get_map('classic')
-    default_palette = cubehelix.Cubehelix(n=256)
-    assert classic_palette.hex_colors[0] == default_palette.hex_colors[0]
-    assert classic_palette.hex_colors[128] == default_palette.hex_colors[128]
-    assert classic_palette.hex_colors[255] == default_palette.hex_colors[255]
-    # Test consistency
-    known_colors = ['#000000', '#237433', '#DB8ACB', '#FFFFFF']
-    palette = cubehelix.Cubehelix(n=4)
-    for c1, c2 in zip(palette.hex_colors, known_colors):
-        assert c1 == c2
+    default_palette = cubehelix.Cubehelix.make(n=16)
+    assert classic_palette.colors == default_palette.colors
 
 
-def test_start_end_hue():
-    # Test to make sure result is consistent
-    palette = cubehelix.Cubehelix(start_hue=240., end_hue=-300.,
-                                  min_sat=1., max_sat=2.5,
-                                  min_light=0.3, max_light=0.8, gamma=.9, n=4)
-    known_colors = ['#873B61', '#677BDC', '#47DF91', '#E9D575']
-    for c1, c2 in zip(palette.hex_colors, known_colors):
-        assert c1 == c2
+def test_classic():
+    palette = cubehelix.Cubehelix.make(start=0.5, rotation=-1.5, gamma=1.0,
+                                       sat=1.2, min_light=0., max_light=1.,
+                                       n=16)
+    assert palette.colors == cubehelix.get_map('classic').colors
+
+
+def test_perceptual_rainbow():
+    palette = cubehelix.Cubehelix.make(start_hue=240., end_hue=-300.,
+                                       min_sat=1., max_sat=2.5,
+                                       min_light=0.3, max_light=0.8, gamma=.9,
+                                       n=16)
+    assert palette.colors == cubehelix.get_map('perceptual_rainbow').colors
+
+
+def test_purple():
+    palette = cubehelix.Cubehelix.make(start=0., rotation=0.0, n=16)
+    assert palette.colors == cubehelix.get_map('purple').colors
+
+
+def test_jim_special():
+    palette = cubehelix.Cubehelix.make(start=0.3, rotation=-0.5, n=16)
+    assert palette.colors == cubehelix.get_map('jim_special').colors
+
+
+def test_red():
+    palette = cubehelix.Cubehelix.make(start=0., rotation=0.5, n=16)
+    assert palette.colors == cubehelix.get_map('red').colors
+
+
+def test_cubehelix1():
+    palette = cubehelix.Cubehelix.make(gamma=1.0, start=1.5,
+                                       rotation=-1.0, sat=1.5, n=16)
+    assert palette.colors == cubehelix.get_map('cubehelix1').colors
+
+
+def test_cubehelix2():
+    palette = cubehelix.Cubehelix.make(gamma=1.0, start=2.0, rotation=1.0,
+                                       sat=1.5, n=16)
+    assert palette.colors == cubehelix.get_map('cubehelix2').colors
+
+
+def test_cubehelix3():
+    palette = cubehelix.Cubehelix.make(gamma=1.0, start=2.0, rotation=1.0,
+                                       sat=3, n=16)
+    assert palette.colors == cubehelix.get_map('cubehelix3').colors

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -36,6 +36,7 @@ def test_get_map_reversed():
     assert palette.colors == palette_r.colors[::-1]
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_make_map_reversed():
     palette = cubehelix.Cubehelix.make(n=16, reverse=False)
     palette_r = cubehelix.Cubehelix.make(n=16, reverse=True)

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -31,7 +31,7 @@ def test_default_is_classic():
     assert classic_palette.hex_colors[128] == default_palette.hex_colors[128]
     assert classic_palette.hex_colors[255] == default_palette.hex_colors[255]
     # Test consistency
-    known_colors = ['#0L0L0L', '#23L74L33L', '#DBL8ALCBL', '#FFLFFLFFL']
+    known_colors = ['#000000', '#237433', '#DB8ACB', '#FFFFFF']
     palette = cubehelix.Cubehelix(n=4)
     for c1, c2 in zip(palette.hex_colors, known_colors):
         assert c1 == c2
@@ -42,6 +42,6 @@ def test_start_end_hue():
     palette = cubehelix.Cubehelix(start_hue=240., end_hue=-300.,
                                   min_sat=1., max_sat=2.5,
                                   min_light=0.3, max_light=0.8, gamma=.9, n=4)
-    known_colors = ['#87L3BL61L', '#67L7BLDCL', '#47LDFL91L', '#E9LD5L75L']
+    known_colors = ['#873B61', '#677BDC', '#47DF91', '#E9D575']
     for c1, c2 in zip(palette.hex_colors, known_colors):
         assert c1 == c2

--- a/palettable/cubehelix/test/test_cubehelix.py
+++ b/palettable/cubehelix/test/test_cubehelix.py
@@ -1,8 +1,13 @@
 # coding: utf-8
 
-# import numpy as np
+try:
+    import pytest
+except ImportError:
+    raise ImportError('Tests require pytest >= 2.2.')
 
 from ... import cubehelix
+
+HAVE_NPY = cubehelix.cubehelix.HAVE_NPY
 
 
 def test_get_map():
@@ -24,12 +29,14 @@ def test_palettes_loaded():
     assert isinstance(cubehelix.classic_r, cubehelix.Cubehelix)
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_default_is_classic():
     classic_palette = cubehelix.get_map('classic')
     default_palette = cubehelix.Cubehelix.make(n=16)
     assert classic_palette.colors == default_palette.colors
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_classic():
     palette = cubehelix.Cubehelix.make(start=0.5, rotation=-1.5, gamma=1.0,
                                        sat=1.2, min_light=0., max_light=1.,
@@ -37,6 +44,7 @@ def test_classic():
     assert palette.colors == cubehelix.get_map('classic').colors
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_perceptual_rainbow():
     palette = cubehelix.Cubehelix.make(start_hue=240., end_hue=-300.,
                                        min_sat=1., max_sat=2.5,
@@ -45,33 +53,39 @@ def test_perceptual_rainbow():
     assert palette.colors == cubehelix.get_map('perceptual_rainbow').colors
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_purple():
     palette = cubehelix.Cubehelix.make(start=0., rotation=0.0, n=16)
     assert palette.colors == cubehelix.get_map('purple').colors
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_jim_special():
     palette = cubehelix.Cubehelix.make(start=0.3, rotation=-0.5, n=16)
     assert palette.colors == cubehelix.get_map('jim_special').colors
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_red():
     palette = cubehelix.Cubehelix.make(start=0., rotation=0.5, n=16)
     assert palette.colors == cubehelix.get_map('red').colors
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_cubehelix1():
     palette = cubehelix.Cubehelix.make(gamma=1.0, start=1.5,
                                        rotation=-1.0, sat=1.5, n=16)
     assert palette.colors == cubehelix.get_map('cubehelix1').colors
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_cubehelix2():
     palette = cubehelix.Cubehelix.make(gamma=1.0, start=2.0, rotation=1.0,
                                        sat=1.5, n=16)
     assert palette.colors == cubehelix.get_map('cubehelix2').colors
 
 
+@pytest.mark.skipif('not HAVE_NPY')
 def test_cubehelix3():
     palette = cubehelix.Cubehelix.make(gamma=1.0, start=2.0, rotation=1.0,
                                        sat=3, n=16)


### PR DESCRIPTION
This PR implements cubehelix color maps in palettable by porting @jradavenport's `cubehelix.py`. I put a [demo notebook up as a gist here](http://nbviewer.ipython.org/gist/jonathansick/1d278baad7345a1281dd). I think it's sweet.

I've kept the API for `palettable.cubehelix` as similar as possible to the other palettes. Basically, the `Cubehelix(Palette)` class computes colors for the color map. `get_map()` is a factory that takes pre-defined parameter sets and creates `Cubehelix` instances. The user is also encouraged to build their own maps directly.

I've spruced up the cubehelix algorithm implementation a bit. Some parameters are renamed for clarity. I also use `numpy.dot()` to build the entire RGB color vector in one statement. Anyways, it's a bit more Pythonic and a little less... Fortranic?

I also noticed a discrepancy between D.A. Green's formula for `phi` and the Fortran code (and the original Python implementation); there's an issue of adding an extra `+1`. I've stayed true to the formula in the paper, although I don't actually notice any difference in the outputs.

Some issues I see:

- This code adds numpy as a dependency, at least to import `palettable.cubehelix`.
- I'm giving the Palettable baseclass colors as a `(n, 3)` numpy array rather than a list of 3-tuples. Surprisingly, this works. The one problem is that hex colors contain an `'L'`, e.g., `'#23L74L33L'`. What's up with this? A `long` type? Is this ok?
- I haven't touched the docs. Maybe @jiffyclub should handle that? I can check the demo notebook into the `demo/` if you think that's a good idea.

Let me know what you think!