### PR TITLE
restore palettable functionality on OS X if Python is no framework

### DIFF
--- a/palettable/palette.py
+++ b/palettable/palette.py
@@ -11,6 +11,8 @@ try:
     from matplotlib.colorbar import ColorbarBase
 except ImportError:     # pragma: no cover
     HAVE_MPL = False
+except RuntimeError:  # e.g. OS X, if Python is not installed as a framework
+    HAVE_MPL = False
 else:
     HAVE_MPL = True
 


### PR DESCRIPTION
Currently, on OS X, if palettable won't import due to matplotlib throwing a `RuntimeError` if Python is not installed as OS X framework:

```
>>> import palettable
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/demo/jupyter/lib/python3.5/site-packages/palettable/__init__.py", line 7, in <module>
    from . import colorbrewer
  File "/Users/demo/jupyter/lib/python3.5/site-packages/palettable/colorbrewer/__init__.py", line 3, in <module>
    from .colorbrewer import *
  File "/Users/demo/jupyter/lib/python3.5/site-packages/palettable/colorbrewer/colorbrewer.py", line 9, in <module>
    from ..palette import Palette
  File "/Users/demo/jupyter/lib/python3.5/site-packages/palettable/palette.py", line 8, in <module>
    import matplotlib.pyplot as plt
  File "/Users/demo/jupyter/lib/python3.5/site-packages/matplotlib/pyplot.py", line 114, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/Users/demo/jupyter/lib/python3.5/site-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup
    globals(),locals(),[backend_name],0)
  File "/Users/demo/jupyter/lib/python3.5/site-packages/matplotlib/backends/backend_macosx.py", line 24, in <module>
    from matplotlib.backends import _macosx
RuntimeError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework. See the Python documentation for more information on installing Python as a framework on Mac OS X. Please either reinstall Python as a framework, or try one of the other backends. If you are Working with Matplotlib in a virtual enviroment see 'Working with Matplotlib in Virtual environments' in the Matplotlib FAQ
```

This PR adds a check for `RuntimeError` for the import of `matplotlib`, so importing `matplotlib` still fails, but palettable is now usable and doesn't fail as well.
