### PR TITLE
Add setuptools as a runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     url='https://jiffyclub.github.io/palettable/',
     packages=find_packages(exclude=["*.test"]),
     package_data={'palettable.colorbrewer': ['data/colorbrewer*']},
+    install_requires=['setuptools'],
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',


### PR DESCRIPTION
This package relies on `pkg_resources` (provided by `setuptools`) at runtime: https://github.com/jiffyclub/palettable/blob/768d5ef8d14437d4bffa27afb96e4990c919a25d/palettable/colorbrewer/colorbrewer.py#L7

an alternative implementation would be to move to `importlib.resources` (and/or the `importlib-resources` backport)