### PR TITLE
Only include palettable module in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,5 @@ changelog = "https://github.com/jiffyclub/palettable/blob/master/CHANGELOG.rst"
 version = {attr = "palettable.VERSION"}
 
 [tool.setuptools.packages.find]
+include = ["palettable"]
 exclude = ["*.test"]


### PR DESCRIPTION
Not having the include, will include docs, scripts and tests
outside the palettable namespace as well.
