### PR TITLE
Fix missing asterisk (#52)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,5 +33,5 @@ changelog = "https://github.com/jiffyclub/palettable/blob/master/CHANGELOG.rst"
 version = {attr = "palettable.VERSION"}
 
 [tool.setuptools.packages.find]
-include = ["palettable"]
+include = ["palettable*"]
 exclude = ["*.test"]


### PR DESCRIPTION
The asterisk is needed or submodules won't be included in some
cases.
